### PR TITLE
[centos6-i386] Fixed yum arch

### DIFF
--- a/centos6-i386/Dockerfile
+++ b/centos6-i386/Dockerfile
@@ -1,4 +1,8 @@
 FROM scratch
 MAINTAINER Toopher, Inc. <dev@toopher.com>
+
 ADD centos6.tar.gz /
+RUN echo "i686" > /etc/yum/vars/arch && \
+    echo "i386" > /etc/yum/vars/basearch
+
 ENTRYPOINT ["linux32"]


### PR DESCRIPTION
This will help those who inherit from this image and run `yum install` in their Dockerfile. Without this fix `yum install` will result in installing x86_64 packages (if your host is x64 OS).
