### PR TITLE
Install `yum-plugin-ovl` to combat overlayfs2 problems with `yum`

### DIFF
--- a/centos6-i386/make-docker-image.sh
+++ b/centos6-i386/make-docker-image.sh
@@ -27,6 +27,8 @@ mknod -m 666 "$target"/dev/zero c 1 5
 
 yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
     --setopt=group_package_types=mandatory -y groupinstall Core
+yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
+    --setopt=group_package_types=mandatory -y install yum-plugin-ovl
 yum -c "$yum_config" --installroot="$target" -y clean all
 
 cat > "$target"/etc/sysconfig/network <<EOF


### PR DESCRIPTION
This adds the `yum-plugin-ovl` package to the base install, which is important for reasons such as this: https://github.com/CentOS/sig-cloud-instance-images/issues/15